### PR TITLE
ros mac 安装脚本完善

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 script:
-  - ./install
+  - travis_wait 90 ./install

--- a/install
+++ b/install
@@ -183,7 +183,7 @@ do_install()
   sudo chown -R $USER:admin /usr/local
   # TODO: change hardcoded version.
   ln -s /usr/local/Cellar/qt5/5.8.0_1/mkspecs /usr/local/mkspecs || true
-  ln -s /usr/local/Cellar/qt5/5.8.0_1/mkspecs /usr/local/plugins || true
+  ln -s /usr/local/Cellar/qt5/5.8.0_1/plugins /usr/local/plugins || true
   ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5 || true
   
   brew remove opencv || true

--- a/install
+++ b/install
@@ -201,6 +201,13 @@ do_install()
   echo
   echo "  source ${ROS_INSTALL_DIR}/setup.bash"
   echo
+
+  if grep -Fxq "export ${ROS_INSTALL_DIR}/setup.bash" ~/.bash_profile
+  then
+    echo "ROS PATH already in ~/.bash_profile"
+  else
+    echo "export ${ROS_INSTALL_DIR}/setup.bash" >> ~/.bash_profile
+  fi
   
   # Check for SIP if on OSX/macOS 10.11 (El Capitan) or later
   if [[ `sw_vers -productVersion` > "10.10" ]]

--- a/install
+++ b/install
@@ -202,11 +202,11 @@ do_install()
   echo "  source ${ROS_INSTALL_DIR}/setup.bash"
   echo
 
-  if grep -Fxq "export ${ROS_INSTALL_DIR}/setup.bash" ~/.bash_profile
+  if grep -Fxq "source ${ROS_INSTALL_DIR}/setup.bash" ~/.bash_profile
   then
     echo "ROS PATH already in ~/.bash_profile"
   else
-    echo "export ${ROS_INSTALL_DIR}/setup.bash" >> ~/.bash_profile
+    echo "source ${ROS_INSTALL_DIR}/setup.bash" >> ~/.bash_profile
   fi
   
   # Check for SIP if on OSX/macOS 10.11 (El Capitan) or later

--- a/install
+++ b/install
@@ -104,6 +104,25 @@ do_install()
   brew link --force qt5 || true
   
   brew remove pyqt5 || true
+  # If installation failed with error:
+  # .  Error: Failed to determine the detail of your Qt installation. Try again using
+  # .  the --verbose flag to see more detail about the problem.
+  # .  Querying qmake about your Qt installation...
+  # .  Determining the details of your Qt installation...
+  # .  /usr/local/opt/qt5/bin/qmake -o qtdetail.mk qtdetail.pro
+  # .  Project ERROR: Could not resolve SDK Path for 'MacOSX10.12'
+  # (1) We need to make sure the Xcode is installed and
+  # MacOS SDK PATH is select to correct location
+  # using: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+  # (2) reinstall qt5:
+  # .  brew uninstall qt5
+  # .  brew install --force qt5
+  # .  brew link --force qt5
+  # (3) finally: brew install pyqt5 --with-python
+  # 
+  # Note: the installation process may take long time,
+  # which will not generate any output in 10 mins
+  # leading travis build failure.
   brew install pyqt5 --with-python
 
   # Initialize and update rosdep


### PR DESCRIPTION
1. pyqt5安装不成功，从报错看最直接原因是找不到苹果系统的SDK路径，当时只安装了命令行的开发工具；尝试在一些qt环境相关的文件中添加SDK路径，仍然安装失败，错误提示相同；安装Xcode后，并`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`，pyqt5仍然安装失败，错误提示相同；由于pyqt5是基于qt5的，所以怀疑是前面安装qt5时SDK路径有问题，使用brew重新安装qt5后，pyqt5顺利的进入了编译。
2. travis build报错，查日志，为十分钟内没有任何打印输出，认为build失败强制停止；在MacBook Air上仅pyqt5编译就需要半个小时，且没有打印输出，而在后面opencv3编译所需时间达到80多分钟；查如何延长这个十分钟的限制，并添加到travis配置中尝试，仍然build失败，且这样的修改会导致install脚本没有任何打印输出，所以对于如何修改.travis.yml以延长十分钟限制还没有比较好的解决方案，请不要合并.travis.yml文件的修改。